### PR TITLE
fix: correct plugin source in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "autology",
-      "source": ".",
+      "source": "Curt-Park/autology",
       "description": "Living Ontology for Claude Code - Prevents erosion of human understanding by capturing and reusing knowledge",
       "version": "0.2.0",
       "author": {


### PR DESCRIPTION
## Problem

When trying to add the plugin to the marketplace:
```bash
/plugin marketplace add Curt-Park/autology
```

User gets this error:
```
Error: Invalid schema: plugins.0.source: Invalid input
```

## Solution

Changed `marketplace.json` source field from `"."` to `"Curt-Park/autology"` to match the GitHub repository format expected by the Claude Code plugin system.

**Before:**
```json
{
  "source": "."
}
```

**After:**
```json
{
  "source": "Curt-Park/autology"
}
```

## Testing

After this fix, the plugin marketplace command should work correctly:
```bash
/plugin marketplace add Curt-Park/autology
/plugin install autology@autology
```

## Changes

- Fixed `.claude-plugin/marketplace.json` source field

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>