### PR TITLE
fix: correct plugin.json schema for Claude Code validator

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -16,9 +16,8 @@
     "learning",
     "transparency"
   ],
-  "hooks": "hooks/hooks.json",
-  "skills": "skills",
-  "agents": "agents",
+  "skills": ["./skills/"],
+  "agents": ["./agents/autology-explorer.md"],
   "mcpServers": {
     "autology": {
       "command": "${CLAUDE_PLUGIN_ROOT}/bin/autology",


### PR DESCRIPTION
## Summary
- Changed `skills` from string to array format: `["./skills/"]`
- Changed `agents` from string to array with explicit file path: `["./agents/autology-explorer.md"]`
- Removed `hooks` field (auto-loaded by convention in Claude Code v2.1+)

## Problem
The `/plugin add Curt-Park/autology` command was failing with schema validation errors because:
- Skills and agents fields were strings instead of required arrays
- The hooks field should not be present (causes duplicate loading in v2.1+)

## Solution
Updated `.claude-plugin/plugin.json` to comply with Claude Code plugin validator schema requirements per the reference documentation.

## Test Plan
- [ ] Run `/plugin add Curt-Park/autology` command
- [ ] Verify plugin installs without schema validation errors
- [ ] Verify skills and agents are loaded correctly
- [ ] Verify hooks are auto-loaded without explicit field

🤖 Generated with [Claude Code](https://claude.com/claude-code)