### PR TITLE
feat: add marketplace.json for plugin installation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,39 @@
+{
+  "name": "autology",
+  "owner": {
+    "name": "Autology Contributors"
+  },
+  "metadata": {
+    "description": "Living Ontology for Claude Code - Prevents erosion of human understanding by capturing and reusing knowledge"
+  },
+  "plugins": [
+    {
+      "name": "autology",
+      "source": "./",
+      "description": "Living Ontology for Claude Code - Prevents erosion of human understanding by capturing and reusing knowledge",
+      "author": {
+        "name": "Autology Contributors"
+      },
+      "homepage": "https://github.com/Curt-Park/autology",
+      "repository": "https://github.com/Curt-Park/autology",
+      "license": "MIT",
+      "keywords": [
+        "knowledge-management",
+        "ontology",
+        "adr",
+        "documentation",
+        "learning",
+        "transparency"
+      ],
+      "category": "workflow",
+      "tags": [
+        "knowledge-management",
+        "ontology",
+        "adr",
+        "documentation",
+        "learning",
+        "transparency"
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Dev: "Claude, add authentication"
 ### Claude Code
 
 ```bash
-/plugin add Curt-Park/autology
+/plugin marketplace add Curt-Park/autology
 ```
 
 The plugin will automatically download the correct binary for your platform (macOS, Linux, or Windows).


### PR DESCRIPTION
## Summary
- Created `.claude-plugin/marketplace.json` with proper schema based on reference repository
- Updated `README.md` installation instructions to use `/plugin marketplace add` command

## Problem
The `/plugin add` command option doesn't exist in Claude Code CLI. The correct installation method is through the marketplace.

## Solution
Added `marketplace.json` following the format from [everything-claude-code](https://github.com/affaan-m/everything-claude-code):
- Top-level metadata: name, owner, description
- Plugins array with autology configuration
- Source set to "./" (relative path)
- Includes all plugin metadata inline

## Changes
1. **marketplace.json**: New file with marketplace schema
2. **README.md**: Updated installation command from `/plugin add` to `/plugin marketplace add`

## Test Plan
- [ ] Run `/plugin marketplace add Curt-Park/autology`
- [ ] Verify plugin installs successfully
- [ ] Verify binary downloads for current platform
- [ ] Verify MCP tools are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)