### PR TITLE
docs: add local testing guide to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-dist/
-.claude-plugin/bin/
+bin/
 *.log
 .DS_Store
 coverage/

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ all: build
 # Build the autology binary
 build:
 	@echo "Building autology..."
-	@mkdir -p .claude-plugin/bin
-	@go build -o .claude-plugin/bin/autology ./cmd/autology
-	@echo "✓ Built: .claude-plugin/bin/autology"
+	@mkdir -p ./bin
+	@go build -o ./bin/autology ./cmd/autology
+	@echo "✓ Built: ./bin/autology"
 
 # Run all tests (unit tests including hooks)
 test:

--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ The plugin will automatically download the correct binary for your platform (mac
 /autology:explore decisions
 ```
 
+## Local Testing
+
+```bash
+git clone https://github.com/Curt-Park/autology.git
+cd autology
+make install  # required once at the beginning (see https://go.dev/doc/install)
+make build  # required whenever the golang code changes
+claude --plugin-dir .
+```
+
 ## Philosophy
 
 When AI writes code, humans should **understand more, not less**.


### PR DESCRIPTION
## Background
Developers contributing to Autology need clear instructions for local testing and development setup.

## Goal
Add concise local testing guide to README.md showing how to clone, build, and test the plugin locally.

## Key Changes
- Add "Local Testing" section to README.md with 5-step workflow
- Update Makefile to build to `./bin/` instead of `.claude-plugin/bin/`
- Update .gitignore to match new build directory

## Verification
```bash
git clone https://github.com/Curt-Park/autology.git
cd autology
make install  # Install Go dependencies
make build    # Build should create ./bin/autology
claude --plugin-dir .  # Test with local plugin directory
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)